### PR TITLE
fix: android build error with react-native 0.72.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,13 +19,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('RingerMode_compileSdkVersion', 29)
+    compileSdkVersion safeExtGet('compileSdkVersion', 33)
     defaultConfig {
-        minSdkVersion safeExtGet('RingerMode_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('RingerMode_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
-
     }
 
     buildTypes {


### PR DESCRIPTION
This PR fixes the following error in RN 0.72

```
Could not determine the dependencies of task ':react-native-ringer-mode:bundleLibRuntimeToJarRelease'.
> Could not create task ':react-native-ringer-mode:compileReleaseJavaWithJavac'. 
```